### PR TITLE
docs: remove python refs for voter balances endpoint

### DIFF
--- a/docs/sdk/clients/usage.md
+++ b/docs/sdk/clients/usage.md
@@ -950,7 +950,6 @@ You may query for:
 - A specific delegate using the username as ID.
 - All blocks forged by a specific delegate.
 - The voters of a specific delegate.
-- Voter balances of a delegate.
 
 :::: tabs
 
@@ -1034,13 +1033,6 @@ print(client.delegates.blocks(delegate_id="goose"))
 ```python
 print(client.delegates.voters(delegate_id="goose"))
 >> {'meta': {'count': 100, ... }}
-```
-
-#### List voter balances for a delegate
-
-```python
-print(client.delegates.voter_balances(delegate_id="goose"))
->> {'data': {'AZpoKsoqHAMWBNqeEf3WNfRCenxLR51pBt': 998386, ... }}
 ```
 
 :::


### PR DESCRIPTION
## Proposed changes

<!--
Remove references to the voter balances for the python section as well as the main part where it describes potential usages of the delegates endpoints
-->

## Types of changes

<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [X] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist

<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're re here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [X] I have read the [CONTRIBUTING](/guidebook/contribution-guidelines/contributing.html) documentation
- [X] I have read the [WRITING DOCUMENTATION](/guidebook/contribution-guidelines/writing-documentation.html) guidelines

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

